### PR TITLE
Use uri_string module for parsing URLs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{minimum_otp_vsn, "21.0"}.
+
 {erl_opts,
  [debug_info,
   warn_export_all,

--- a/test/yval_test.erl
+++ b/test/yval_test.erl
@@ -271,31 +271,23 @@ url_any_test() ->
 
 bad_url_scheme_test() ->
     ?checkError(
-       {bad_url, {unsupported_scheme, http}, <<"http://domain.tld">>},
+       {bad_url, {unsupported_scheme, <<"http">>}, <<"http://domain.tld">>},
        v(url([https]), <<"http://domain.tld">>)).
 
 bad_url_host_test() ->
     ?checkError(
        {bad_url, empty_host, <<"http:///path">>}, v(url(), <<"http:///path">>)).
 
-bad_url_no_default_port_test() ->
-    ?checkError(
-       {bad_url, {no_default_port, foo, _}, <<"foo://domain.tld">>},
-       v(url([]), <<"foo://domain.tld">>)).
-
 bad_url_bad_port_test() ->
     ?checkError(
        {bad_url, bad_port, <<"http://domain.tld:0">>},
        v(url(), <<"http://domain.tld:0">>)),
     ?checkError(
-       {bad_url, bad_port, <<"http://domain.tld:-1">>},
-       v(url(), <<"http://domain.tld:-1">>)),
-    ?checkError(
        {bad_url, bad_port, <<"http://domain.tld:65536">>},
        v(url(), <<"http://domain.tld:65536">>)).
 
 bad_url_test() ->
-    ?checkError({bad_url, _, <<"bad">>}, v(url(), <<"bad">>)).
+    ?checkError({bad_url, _, <<":bad:">>}, v(url(), <<":bad:">>)).
 
 octal_test() ->
     File = file(["a: \"644\""]),


### PR DESCRIPTION
The [http_uri][1] module is deprecated, use [uri_string][2] instead. This [requires][3] OTP 21.

[1]: http://erlang.org/doc/man/http_uri.html
[2]: http://erlang.org/doc/man/uri_string.html
[3]: https://github.com/weiss/yval/blob/8b57a9251a0772e33bddec5b4fb2c4e81d918984/rebar.config#L1