### PR TITLE
Revert to expecting url/1 schemes to be atoms rather than binaries

### DIFF
--- a/src/yval.erl
+++ b/src/yval.erl
@@ -369,10 +369,11 @@ directory(write) ->
 
 -spec url() -> validator(binary()).
 url() ->
-    url([<<"http">>, <<"https">>]).
+    url([http, https]).
 
 -spec url([atom()]) -> validator(binary()).
-url(Schemes) ->
+url(Schemes0) ->
+    Schemes = [atom_to_binary(S) || S <- Schemes0],
     fun(Val) ->
             URL = to_binary(Val),
             case uri_string:parse(URL) of


### PR DESCRIPTION
For backwards compatibility (and because I forgot to update [the `url/1` spec][1] in 2bcf273da44ca851a45241463e82e7ea7bc9735c anyway).

[1]: https://github.com/zinid/yval/blob/eca31df6bafbb77bbd1ecd058f2fd9fe64146211/src/yval.erl#L374