### PR TITLE
Don't depend on 'inets' application

### DIFF
--- a/src/yval.app.src
+++ b/src/yval.app.src
@@ -19,7 +19,7 @@
   {vsn,          "1.0.5"},
   {modules,      []},
   {registered,   []},
-  {applications, [kernel, stdlib, inets]},
+  {applications, [kernel, stdlib]},
   {env,          []},
 
   %% hex.pm packaging:


### PR DESCRIPTION
I _think_ `inets` was only pulled in to get `uri_string:parse/1`, which is [no longer][1] used.

[1]: https://github.com/zinid/yval/commit/2bcf273da44ca851a45241463e82e7ea7bc9735c